### PR TITLE
Enhance image pushes on main for Forks

### DIFF
--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -51,6 +51,8 @@ jobs:
   build-all-binaries:
     needs: [linux-tests, windows-tests, chart-tests]
     runs-on: windows-2022
+    if: |
+      github.repository_owner == "rancher" || vars.REPO != ""
     env:
       REPO: ${{ vars.REPO }}
     steps:


### PR DESCRIPTION
when merging to main, only push images if the fork has REPO set, or is owned by Rancher. This stops forks from trying to push to the official rancher repositories when syncing the main branch, but still allows forks to push images on merges if they choose.